### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - pip install bibtexparser
   - pip install six
   - pip install crossrefapi
-  - pip install fuzzywuzzy
+  - pip install rapidfuzz
   - pip install unidecode
   - pip install scholarly
 # test coverage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Dependencies
 - [bibtexparser (1.0.1)](https://bibtexparser.readthedocs.io) : parse bibtex files
 - [crossrefapi (1.2.0)](https://github.com/fabiobatalha/crossrefapi) : make polite requests to crossref API
 - [scholarly (0.2.2)](https://github.com/OrganicIrradiation/scholarly) : interface for google scholar
-- [fuzzywuzzy (0.15.1)](https://github.com/seatgeek/fuzzywuzzy) : calculate score to sort crossref requests
+- [rapidfuzz (0.2.0)](https://github.com/rhasspy/rapidfuzz) : calculate score to sort crossref requests
 - [unidecode (0.04.21)](https://github.com/avian2/unidecode) : replace unicode with ascii equivalent
 - [six](http://pythonhosted.org/six): python 2-3 compatibility
 

--- a/papers/bib.py
+++ b/papers/bib.py
@@ -156,7 +156,7 @@ def compare_entries(e1, e2, fuzzy=False):
         score = 0
 
     else:
-        from fuzzywuzzy.fuzz import token_set_ratio
+        from rapidfuzz.fuzz import token_set_ratio
         doi1, tag1 = id1
         doi2, tag2 = id2
         score = token_set_ratio(tag1, tag2)
@@ -1140,14 +1140,14 @@ def main():
         entries = my.db.entries
 
         if o.fuzzy:
-            from fuzzywuzzy import fuzz
+            from rapidfuzz import fuzz
 
         def match(word, target, fuzzy=False, substring=False):
             if isinstance(target, list):
                 return any([match(word, t, fuzzy, substring) for t in target])
 
             if fuzzy:
-                res = fuzz.token_set_ratio(word.lower(), target.lower()) > o.fuzzy_ratio
+                res = fuzz.token_set_ratio(word, target, score_cutoff=o.fuzzy_ratio) > o.fuzzy_ratio
             elif substring:
                 res = target.lower() in word.lower()
             else:

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -242,7 +242,7 @@ def _get_page_fast(pagerequest):
 
 def _scholar_score(txt, bib):
     # high score means high similarity
-    from fuzzywuzzy.fuzz import token_set_ratio
+    from rapidfuzz.fuzz import token_set_ratio
     return sum([token_set_ratio(bib[k], txt) for k in ['title', 'author', 'abstract'] if k in bib])
 
 
@@ -281,7 +281,7 @@ def _crossref_get_author(res, sep=u'; '):
 
 def _crossref_score(txt, r):
     # high score means high similarity
-    from fuzzywuzzy.fuzz import token_set_ratio
+    from rapidfuzz.fuzz import token_set_ratio
     score = 0
     if 'author' in r:
         author = ' '.join([p['family'] for p in r.get('author',[]) if 'family' in p])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ unidecode
 crossrefapi
 bibtexparser
 scholarly
-fuzzywuzzy
+rapidfuzz
 six

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='papers',
       packages=['papers'],
       scripts=['scripts/papers'],
       license = "MIT",
-      requires = ["bibtexparser","crossrefapi","fuzzywuzzy", "unidecode", "scholarly", "six"],
+      requires = ["bibtexparser","crossrefapi","rapidfuzz", "unidecode", "scholarly", "six"],
       )
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,6 @@ deps =
     six
     scholarly
     crossrefapi
-    fuzzywuzzy
+    rapidfuzz
     unidecode
     pytest


### PR DESCRIPTION
FuzzyWuzzy and Python-Levenshtein are both GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.