### PR TITLE
Import papers.duplicate.entry_diff for fix_entry()

### DIFF
--- a/papers/bib.py
+++ b/papers/bib.py
@@ -28,6 +28,7 @@ from papers.config import config, bcolors, checksum, move
 
 from papers.duplicate import check_duplicates, resolve_duplicates, conflict_resolution_on_insert
 from papers.duplicate import search_duplicates, list_duplicates, list_uniques, merge_files, edit_entries
+from papers.duplicate import entry_diff
 
 # DRYRUN = False
 


### PR DESCRIPTION
Running ``~> papers list --key BIBKEY --fetch`` in an interactive shell results in an exception because the relevant function is not imported:
```
*** UPDATE ***                                                                                                                                      
Traceback (most recent call last):                                                                                                                   
  File "/usr/bin/papers", line 5, in <module>                                                                                                        
    papers.bib.main()                                                                                                                                
  File "/usr/lib/python3.9/site-packages/papers/bib.py", line 1356, in main                                                                          
    check_install() and listcmd(o)                                                                                                                   
  File "/usr/lib/python3.9/site-packages/papers/bib.py", line 1233, in listcmd                                                                       
    my.fix_entry(e, fix_doi=True, fix_key=True, fetch_all=True, interactive=True)                                                                    
  File "/usr/lib/python3.9/site-packages/papers/bib.py", line 619, in fix_entry                                                                      
    print(entry_diff(e_old, e))                                                                                                                      
NameError: name 'entry_diff' is not defined
```
Importing entry_diff from papers.duplicate fixes this.
