### PR TITLE
fix: Does not install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import versioneer
 
 version = versioneer.get_version()
@@ -14,5 +14,5 @@ setup(name='papers-cli',
       packages=['papers'],
       scripts=['scripts/papers'],
       license = "MIT",
-      requires = ["bibtexparser","crossrefapi","rapidfuzz", "unidecode", "scholarly", "six"],
+      install_requires = ["bibtexparser","crossrefapi","rapidfuzz", "unidecode", "scholarly", "six"],
       )


### PR DESCRIPTION
There is no such argument as `requires` in `distutils.core.setup()` (see [docs](https://docs.python.org/3/distutils/apiref.html#distutils.core.setup)). That is why executing `pip install papers-cli` does not install dependencies such as `six`, `bibtexparser`, etc.
This PR fixes this.

As you can see [here](https://docs.python.org/3/distutils/index.html), `disutils` package is deprecated and should not be used. That's why I suggest to switch from `disutils` to `setuptools`.
Furthermore, there is no dependency resolving feature in `disutils` afaik.