### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.egg-info/
 *.pyc
 .tox
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ notifications:
 before_install:
   - pip install pip --upgrade
   - pip install bibtexparser
-  - pip install six
   - pip install crossrefapi
   - pip install rapidfuzz
   - pip install unidecode

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - python setup.py install
 
-script: py.test -xv --cov papers.bib tests
+script: pytest -xv --cov papers.bib tests
 #script: tox -e py27 -e py34
 
 after-success: coveralls

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Dependencies
 - [scholarly (0.2.2)](https://github.com/OrganicIrradiation/scholarly) : interface for google scholar
 - [rapidfuzz (0.2.0)](https://github.com/rhasspy/rapidfuzz) : calculate score to sort crossref requests
 - [unidecode (0.04.21)](https://github.com/avian2/unidecode) : replace unicode with ascii equivalent
-- [six](http://pythonhosted.org/six): python 2-3 compatibility
 
 Install
 -------

--- a/papers/__init__.py
+++ b/papers/__init__.py
@@ -1,5 +1,3 @@
-
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/papers/bib.py
+++ b/papers/bib.py
@@ -1,4 +1,4 @@
-import os, json, sys
+import os
 import logging
 # logger.basicConfig(level=logger.INFO)
 import argparse
@@ -6,9 +6,6 @@ import subprocess as sp
 import shutil
 import bisect
 import itertools
-import six
-from six.moves import input as raw_input
-import re
 
 import bibtexparser
 
@@ -616,7 +613,7 @@ class Biblio:
             print(bcolors.OKBLUE+'*** UPDATE ***'+bcolors.ENDC)
             print(entry_diff(e_old, e))
 
-            if raw_input('update ? [Y/n] or [Enter] ').lower() not in ('', 'y'):
+            if input('update ? [Y/n] or [Enter] ').lower() not in ('', 'y'):
                 logger.info('cancel changes')
                 e.update(e_old)
                 for k in list(e.keys()):
@@ -717,7 +714,7 @@ def entry_filecheck(e, delete_broken=False, fix_mendeley=False,
                 logger.info('delete file from entry: "{}"'.format(file))
                 continue
             elif interactive:
-                ans = raw_input('delete file from entry ? [Y/n] ')
+                ans = input('delete file from entry ? [Y/n] ')
                 if ans.lower == 'y':
                     continue
 
@@ -824,7 +821,7 @@ def main():
         old = o.bibtex
 
         if config.git and not o.git and o.bibtex == config.bibtex:
-            ans = raw_input('stop git tracking (this will not affect actual git directory)? [Y/n] ')
+            ans = input('stop git tracking (this will not affect actual git directory)? [Y/n] ')
             if ans.lower() != 'y':
                 o.git = True
 
@@ -858,7 +855,7 @@ def main():
             logger.warn('Cannot make global install if local config file exists.')
             ans = None
             while ans not in ('1','2'):
-                ans = raw_input('(1) remove local config file '+local_config+'\n(2) make local install\nChoice: ')
+                ans = input('(1) remove local config file '+local_config+'\n(2) make local install\nChoice: ')
             if ans == '1':
                 os.remove(local_config)
             else:

--- a/papers/bib.py
+++ b/papers/bib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 import os, json, sys
 import logging
 # logger.basicConfig(level=logger.INFO)
@@ -73,7 +71,7 @@ def generate_key(entry, nauthor=NAUTHOR, ntitle=NTITLE, minwordlen=3, mintitlen=
         titletag = ''
     else:
         words = [word for word in entry['title'].lower().strip().split() if len(word) >= minwordlen]
-        while len(u''.join(words[:ntitle])) < mintitlen and ntitle < len(words):
+        while len(''.join(words[:ntitle])) < mintitlen and ntitle < len(words):
             ntitle += 1
         titletag = '_'.join(words[:ntitle])
     key = authortag + yeartag + titletag
@@ -217,7 +215,7 @@ def backupfile(bibtex):
 class DuplicateKeyError(ValueError):
     pass
 
-class Biblio(object):
+class Biblio:
     """main config
     """
     def __init__(self, db=None, filesdir=None, key_field='ID', nauthor=NAUTHOR, ntitle=NTITLE, similarity=DEFAULT_SIMILARITY):
@@ -359,11 +357,11 @@ class Biblio(object):
 
     def generate_key(self, entry):
         " generate a unique key not yet present in the record "
-        keys = set(self.key(e) for e in self.db.entries)
+        keys = {self.key(e) for e in self.db.entries}
         return generate_key(entry, keys=keys, nauthor=self.nauthor, ntitle=self.ntitle)
 
     def append_abc_to_key(self, entry):
-        return append_abc(entry['ID'], keys=set(self.key(e) for e in self.entries))
+        return append_abc(entry['ID'], keys={self.key(e) for e in self.entries})
 
 
     def add_bibtex(self, bibtex, **kw):
@@ -505,7 +503,7 @@ class Biblio(object):
                 f.write(bibtex)
 
             # remove old direc if empty?
-            direcs = list(set([os.path.dirname(file) for file in files]))
+            direcs = list({os.path.dirname(file) for file in files})
             if len(direcs) == 1:
                 leftovers = os.listdir(direcs[0])
                 if not leftovers or len(leftovers) == 1 and leftovers[0] == os.path.basename(hidden_bibtex(direcs[0])):
@@ -702,7 +700,7 @@ def entry_filecheck(e, delete_broken=False, fix_mendeley=False,
                     file = candidate
 
             if old != file:
-                logger.info(e['ID']+u': file name fixed: "{}" => "{}".'.format(old, file))
+                logger.info(e['ID']+': file name fixed: "{}" => "{}".'.format(old, file))
                 fixed[old] = file # keep record of fixed files
 
         # parse PDF and check for metadata
@@ -886,7 +884,7 @@ def main():
 
 
     def savebib(my, o):
-        logger.info(u'save '+o.bibtex)
+        logger.info('save '+o.bibtex)
         if papers.config.DRYRUN:
             return
         if my is not None:
@@ -1186,7 +1184,7 @@ def main():
             first_author = lambda field : family_names(field)[0]
             entries = [e for e in entries if 'author' in e and match(firstauthor(e['author']), o.author)]
         if o.author:
-            author = lambda field : u' '.join(family_names(field))
+            author = lambda field : ' '.join(family_names(field))
             entries = [e for e in entries if 'author' in e and longmatch(author(e['author']), o.author)]
         if o.title:
             entries = [e for e in entries if 'title' in e and longmatch(e['title'], o.title)]

--- a/papers/config.py
+++ b/papers/config.py
@@ -48,7 +48,7 @@ def check_filesdir(folder):
     return file_count, folder_size
 
 
-class Config(object):
+class Config:
     """configuration class to specify system-wide collections and files-dir
     """
     def __init__(self, file=CONFIG_FILE, data=DATA_DIR, cache=CACHE_DIR,
@@ -202,10 +202,7 @@ def cached(file, hashed_key=False):
             cache = {}
         def decorated(doi):
             if hashed_key: # use hashed parameter as key (for full text query)
-                if six.PY3:
-                    key = hashlib.sha256(doi.encode('utf-8')).hexdigest()[:6]
-                else:
-                    key = hashlib.sha256(doi).hexdigest()[:6]
+                key = hashlib.sha256(doi.encode('utf-8')).hexdigest()[:6]
             else:
                 key = doi
             if key in cache:
@@ -258,12 +255,12 @@ def move(f1, f2, copy=False, interactive=True):
             return
 
     if copy:
-        cmd = u'cp {} {}'.format(f1, f2)
+        cmd = 'cp {} {}'.format(f1, f2)
         logger.info(cmd)
         if not DRYRUN:
             shutil.copy(f1, f2)
     else:
-        cmd = u'mv {} {}'.format(f1, f2)
+        cmd = 'mv {} {}'.format(f1, f2)
         logger.info(cmd)
         if not DRYRUN:
             shutil.move(f1, f2)

--- a/papers/config.py
+++ b/papers/config.py
@@ -1,9 +1,7 @@
-import os, json, shutil
+import os, json
 import subprocess as sp, sys, shutil
 import hashlib
 import bibtexparser
-import six
-from six.moves import input as raw_input
 from papers import logger
 
 # GIT = False
@@ -250,7 +248,7 @@ def move(f1, f2, copy=False, interactive=True):
         logger.info('dest is identical to src: '+f1)
         return
     if os.path.exists(f2):
-        ans = raw_input('dest file already exists: '+f2+'. Replace? (y/n) ')
+        ans = input('dest file already exists: '+f2+'. Replace? (y/n) ')
         if ans != 'y':
             return
 

--- a/papers/duplicate.py
+++ b/papers/duplicate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 import operator
 import os
 import itertools
@@ -50,7 +48,7 @@ def groupby_equal(entries, eq=None):
         else:
             group = groups[k]
         group.append(e)
-    return sorted(six.iteritems(groups)) 
+    return sorted(groups.items()) 
 
 
 def search_duplicates(entries, key=None, eq=None, issorted=False, filter_key=None):
@@ -110,7 +108,7 @@ def list_uniques(entries, **kw):
 # ==================
 
 
-class ConflictingField(object):
+class ConflictingField:
     def __init__(self, choices=[]):
         self.choices = choices
 
@@ -221,14 +219,14 @@ def entry_ndiff(entries, color=True):
         if matches:
             k = matches[0]
             template = SECRET_STRING.format(k)
-            lines.append(u'\u2304'*3)
+            lines.append('\u2304'*3)
             for c in choices[k]:
-                newline = '  '+line.replace(template, u'{}'.format(c))
+                newline = '  '+line.replace(template, '{}'.format(c))
                 lines.append(_colordiffline(newline, '!') if color else newline)
                 lines.append('---')
             lines.pop() # remove last ---
             # lines.append('^^^')
-            lines.append(u'\u2303'*3)
+            lines.append('\u2303'*3)
         elif any('{} = {{'.format(k) in line for k in somemissing):
             newline = '  '+line
             lines.append(_colordiffline(newline, sign='*') if color else newline)
@@ -368,7 +366,7 @@ def edit_entries(entries, diff=False, ndiff=False):
     with open(filename, 'w') as f:
         f.write(entrystring)
 
-    res = os.system('%s %s' % (os.getenv('EDITOR'), filename))
+    res = os.system('{} {}'.format(os.getenv('EDITOR'), filename))
 
     if res == 0:
         logger.info('sucessfully edited file, insert edited entries')
@@ -396,7 +394,7 @@ class DuplicateSkipAll(Exception):
     pass
 
 
-class DuplicateHandler(object):
+class DuplicateHandler:
 
     def __init__(self, entries):
         self.entries = entries

--- a/papers/duplicate.py
+++ b/papers/duplicate.py
@@ -1,8 +1,6 @@
 import operator
 import os
 import itertools
-import six
-from six.moves import input as raw_input
 import re
 import difflib
 
@@ -259,8 +257,6 @@ def entry_sdiff(entries, color=True, bcolors=bcolors, best=None):
     for i, entry in enumerate(entries):
         db.entries[0] = entry
         string = bibtexparser.dumps(db)
-        if six.PY2:
-            string = string.decode('utf-8') # decode to avoid failure in replace
         # color the conflicting fields
         lines = []
         for line in string.splitlines():
@@ -323,7 +319,7 @@ def _ask_pick_loop(entries, extra=[], select=False):
 
     while True:
         print('choices: '+', '.join(choices))
-        i = raw_input('>>> ')
+        i = input('>>> ')
         try:
             return _process_choice(i)
         except:
@@ -359,9 +355,6 @@ def edit_entries(entries, diff=False, ndiff=False):
         db = bibtexparser.bibdatabase.BibDatabase()
         db.entries.extend(entries)
         entrystring = bibtexparser.dumps(db)
-
-    if six.PY2:
-        entrystring = entrystring.encode('utf-8')
 
     with open(filename, 'w') as f:
         f.write(entrystring)
@@ -483,7 +476,7 @@ class DuplicateHandler:
                 ans = None
                 while ans not in choices:
                     print('choices: '+', '.join(choices))
-                    ans = raw_input('>>> ')
+                    ans = input('>>> ')
                 e = ans
 
             if e == 'm':
@@ -592,7 +585,7 @@ def conflict_resolution_on_insert(old, new, mode='i'):
         ans = None
         while ans not in choices:
             print('choices: '+', '.join(choices))
-            ans = raw_input('>>> ')
+            ans = input('>>> ')
         mode = ans
 
     # overwrite?

--- a/papers/encoding.py
+++ b/papers/encoding.py
@@ -1,4 +1,3 @@
-
 import os
 import six
 import bibtexparser

--- a/papers/encoding.py
+++ b/papers/encoding.py
@@ -1,16 +1,7 @@
 import os
-import six
 import bibtexparser
 from papers.latexenc import latex_to_unicode, unicode_to_latex
 from unidecode import unidecode as unicode_to_ascii
-
-# fix bibtexparser issue
-if six.PY2:
-    _bloads = bibtexparser.loads 
-    _bdumps = bibtexparser.dumps
-    bibtexparser.loads = lambda s: (_bloads(s.decode('utf-8') if type(s) is str else s))
-    bibtexparser.dumps = lambda db: _bdumps(db).encode('utf-8')
-
 
 # fix bibtexparser call on empty strings
 _bloads_orig = bibtexparser.loads

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -1,10 +1,7 @@
 import os
 import json
-import six
 import subprocess as sp
-# import six.moves.urllib.request
 import re
-import shutil
 import tempfile
 
 from crossref.restful import Works, Etiquette
@@ -331,8 +328,6 @@ def crossref_to_bibtex(r):
         ID = r['author'][0]['family'] + '_' + year
     else:
         ID = year
-    # if six.PY2:
-        # ID = str(''.join([c if ord(c) < 128 else '_' for c in ID]))  # make sure the resulting string is ASCII
     bib['ID'] = ID
 
     db = bibtexparser.bibdatabase.BibDatabase()

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import json
 import six
@@ -178,7 +177,7 @@ def extract_txt_metadata(txt, search_doi=True, search_fulltext=False, max_query_
             logger.debug('doi query successful')
 
         except DOIParsingError as error:
-            logger.debug(u'doi parsing error: '+str(error))
+            logger.debug('doi parsing error: '+str(error))
 
         except DOIRequestError as error:
             return '''@misc{{{doi},
@@ -237,13 +236,13 @@ def _get_page_fast(pagerequest):
     if resp.status_code == 200:
         return resp.text
     else:
-        raise Exception('Error: {0} {1}'.format(resp.status_code, resp.reason))
+        raise Exception('Error: {} {}'.format(resp.status_code, resp.reason))
 
 
 def _scholar_score(txt, bib):
     # high score means high similarity
     from rapidfuzz.fuzz import token_set_ratio
-    return sum([token_set_ratio(bib[k], txt) for k in ['title', 'author', 'abstract'] if k in bib])
+    return sum(token_set_ratio(bib[k], txt) for k in ['title', 'author', 'abstract'] if k in bib)
 
 
 @cached('scholar-bibtex.json', hashed_key=True)
@@ -275,7 +274,7 @@ def fetch_bibtex_by_fulltext_scholar(txt, assess_results=True):
 
 
 
-def _crossref_get_author(res, sep=u'; '):
+def _crossref_get_author(res, sep='; '):
     return sep.join([p.get('given','') + p['family'] for p in res.get('author',[]) if 'family' in p])
 
 
@@ -299,7 +298,7 @@ def crossref_to_bibtex(r):
     bib = {}
 
     if 'author' in r:
-        family = lambda p: p['family'] if len(p['family'].split()) == 1 else u'{'+p['family']+u'}'
+        family = lambda p: p['family'] if len(p['family'].split()) == 1 else '{'+p['family']+'}'
         bib['author'] = ' and '.join([family(p) + ', '+ p.get('given','')
             for p in r.get('author',[]) if 'family' in p])
 
@@ -329,7 +328,7 @@ def crossref_to_bibtex(r):
     # bibtex key
     year = str(bib.get('year','0000'))
     if 'author' in r:
-        ID = r['author'][0]['family'] + u'_' + six.u(year)
+        ID = r['author'][0]['family'] + '_' + year
     else:
         ID = year
     # if six.PY2:
@@ -344,7 +343,7 @@ def crossref_to_bibtex(r):
 # @cached('crossref-bibtex-fulltext.json', hashed_key=True)
 def fetch_bibtex_by_fulltext_crossref(txt, **kw):
     work = Works(etiquette=my_etiquette)
-    logger.debug(six.u('crossref fulltext seach:\n')+six.u(txt))
+    logger.debug('crossref fulltext seach:\n'+txt)
 
     # get the most likely match of the first results
     # results = []

--- a/papers/latexenc.py
+++ b/papers/latexenc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # Original source: github.com/okfn/bibserver
 # Authors:
@@ -83,7 +82,7 @@ def latex_to_unicode(string):
     # string, that is always having only compound accentuated character (letter
     # + accent) or single accentuated character (letter with accent). We choose
     # to normalize to the latter.
-    cleaned_string = unicodedata.normalize("NFC", u"".join(cleaned_string))
+    cleaned_string = unicodedata.normalize("NFC", "".join(cleaned_string))
 
     # Remove any left braces
     cleaned_string = cleaned_string.replace("{", "").replace("}", "")
@@ -98,7 +97,7 @@ def protect_uppercase(string):
     :param string: string to convert
     :returns: string
     """
-    string = re.sub('([^{]|^)([A-Z])([^}]|$)', '\g<1>{\g<2>}\g<3>', string)
+    string = re.sub('([^{]|^)([A-Z])([^}]|$)', r'\g<1>{\g<2>}\g<3>', string)
     return string
 
 
@@ -2691,15 +2690,9 @@ def prepare_unicode_to_latex():
         ("\uD7FF", "\\mathtt{9}"),
     )
 
-    if sys.version_info >= (3, 0):
-        unicode_to_latex = to_latex
-        unicode_to_crappy_latex1 = to_crappy1
-        unicode_to_crappy_latex2 = to_crappy2
-        unicode_to_latex_map = dict(unicode_to_latex)
-    else:
-        unicode_to_latex = tuple((k.decode('unicode-escape'), v) for k, v in to_latex)
-        unicode_to_crappy_latex1 = tuple((k.decode('unicode-escape'), v) for k, v in to_crappy1)
-        unicode_to_crappy_latex2 = tuple((k.decode('unicode-escape'), v) for k, v in to_crappy2)
-        unicode_to_latex_map = dict(unicode_to_latex)
+    unicode_to_latex = to_latex
+    unicode_to_crappy_latex1 = to_crappy1
+    unicode_to_crappy_latex2 = to_crappy2
+    unicode_to_latex_map = dict(unicode_to_latex)
 
 prepare_unicode_to_latex()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ crossrefapi
 bibtexparser
 scholarly
 rapidfuzz
-six

--- a/scripts/papers
+++ b/scripts/papers
@@ -1,4 +1,4 @@
-#!/bin/env python2.7
+#!/bin/env python3
 import papers.bib
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python =
     3.8: py38
 
 [testenv]
-commands = py.test tests -xv
+commands = pytest tests -xv
 deps =
     bibtexparser
     six

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ python =
 commands = pytest tests -xv
 deps =
     bibtexparser
-    six
     scholarly
     crossrefapi
     rapidfuzz

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(name='papers-cli',
       packages=['papers'],
       scripts=['scripts/papers'],
       license = "MIT",
-      requires = ["bibtexparser","crossrefapi","rapidfuzz", "unidecode", "scholarly", "six"],
+      requires=["bibtexparser", "crossrefapi", "rapidfuzz", "unidecode", "scholarly"],
       )

--- a/tests/download.py
+++ b/tests/download.py
@@ -1,8 +1,7 @@
-#!/bin/env python2.7
-import six
-import six.moves.urllib.request
+#!/bin/env python3
 import os
 import logging
+import urllib.request
 
 DOWNDIR = os.path.join(os.path.dirname(__file__), 'downloadedpapers')
 
@@ -11,6 +10,7 @@ URL = {
     'esd-4-11-2013.pdf': 'https://www.earth-syst-dynam.net/4/11/2013/esd-4-11-2013.pdf',
     'esd-4-11-2013-supplement.pdf': 'https://www.earth-syst-dynam.net/4/11/2013/esd-4-11-2013-supplement.pdf',
 }
+
 
 def _downloadpdf(url, filename, overwrite=False):
 
@@ -25,7 +25,7 @@ def _downloadpdf(url, filename, overwrite=False):
 
     print('download',url,'to',filename)
 
-    response = six.moves.urllib.request.urlopen(url)
+    response = urllib.request.urlopen(url)
     resp = response.read()
 
     with open(filename, 'wb') as f:

--- a/tests/download.py
+++ b/tests/download.py
@@ -1,5 +1,4 @@
 #!/bin/env python2.7
-from __future__ import print_function
 import six
 import six.moves.urllib.request
 import os

--- a/tests/test_papers.py
+++ b/tests/test_papers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import
-
 import unittest
 import os, subprocess as sp
 import tempfile, shutil
@@ -429,7 +427,7 @@ class TestDuplicates(unittest.TestCase):
 
 
 
-class SimilarityBase(object):
+class SimilarityBase:
 
     similarity = None
 


### PR DESCRIPTION
Fixes https://github.com/perrette/papers/issues/17.

---

What is the minimum Python 3 version supported? We could modernise further to match.

Python 3.7 is the oldest still supported by the core CPython team: 

* https://endoflife.date/python

And Scientific Python projects often follow NEP 29, with 3.7 as a minimum: 

* https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table