### PR TITLE
Add straightforward version printing to stdio.

### DIFF
--- a/papers/bib.py
+++ b/papers/bib.py
@@ -14,6 +14,8 @@ from bibtexparser.customization import convert_to_unicode
 import papers
 from papers import logger
 
+from papers._version import __version__
+
 from papers.extract import extract_pdf_doi, isvaliddoi, parse_doi
 from papers.extract import extract_pdf_metadata
 from papers.extract import fetch_bibtex_by_fulltext_crossref, fetch_bibtex_by_doi
@@ -890,9 +892,15 @@ def main():
         parents=[cfg])
     statusp.add_argument('--no-check-files', action='store_true', help='faster, less info')
     statusp.add_argument('-v','--verbose', action='store_true', help='app status info')
+    statusp.add_argument('--version', action='store_true', help='Print version string and quit.')
 
     def statuscmd(o):
-        print(config.status(check_files=not o.no_check_files, verbose=o.verbose))
+        if o.version:
+            version = str(__version__)
+            print(version)
+            del version
+        else:
+            print(config.status(check_files=not o.no_check_files, verbose=o.verbose))
 
 
     # install


### PR DESCRIPTION
This adds a tiny convenience function, so that 
```
papers status --version
```
will show you the version of the currently installed ``papers`` you have, so that you can figure out if ``papers`` in $PATH is what you think it is.