### PR TITLE
add {posargs} to tox pytest command (instead of tests) 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ python =
     3.11: py311
 
 [testenv]
-commands = pytest --cov=papers --cov-append --cov-report=term-missing tests -xv
+commands = pytest --cov=papers --cov-append --cov-report=term-missing {posargs} -xv
 deps =
     bibtexparser
     scholarly


### PR DESCRIPTION
It's now possible to run single tests from tox. The default automatically detects tests anyways.