### PR TITLE
set the git directory to bibtex dir by default

### DIFF
--- a/papers/config.py
+++ b/papers/config.py
@@ -174,7 +174,7 @@ class Config:
     def gitinit(self, branch=None):
         if not os.path.exists(self._gitdir):
             # with open(os.devnull, 'w') as shutup:
-            sp.check_call(['git','init'], cwd=self.gitdir)
+            sp.check_call(['git','init'], cwd=self.gitdir or None)
             if self.gitlfs:
                 try:
                     sp.check_call('git lfs track "files/**"', cwd=self.gitdir, shell=True) # this does not seem to work


### PR DESCRIPTION
- the purpose of git tracking via papers is getting less acute with local install, but in any case it is intended to keep track of bibtex before everything else. This change is consistent with the original default to global install under .share/papers