### PR TITLE
Call main() instead of shell's papers to speed-up tests

### DIFF
--- a/papers/utils.py
+++ b/papers/utils.py
@@ -2,6 +2,9 @@ import os
 import shutil
 import hashlib
 
+from contextlib import contextmanager
+from pathlib import Path
+
 from papers import logger
 
 
@@ -117,3 +120,24 @@ def move(f1, f2, copy=False, interactive=True, dryrun=False, hardlink=True):
         logger.info(cmd)
         if not dryrun:
             shutil.move(f1, f2)
+
+
+
+
+@contextmanager
+def set_directory(path: Path):
+    """Sets the cwd within the context
+
+    Args:
+        path (Path): The path to the cwd
+
+    Yields:
+        None
+    """
+
+    origin = Path().absolute()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(origin)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -13,10 +13,10 @@ class TestSimple(unittest.TestCase):
         self.assertTrue(os.path.exists(self.pdf))
 
     def test_doi(self):
-        self.assertEqual(paperscmd(f'doi {self.pdf}').strip(), self.doi)
+        self.assertEqual(paperscmd(f'doi {self.pdf}', sp_cmd='check_output').strip(), self.doi)
 
     def test_fetch(self):
-        bibtexs = paperscmd(f'fetch {self.doi}').strip()
+        bibtexs = paperscmd(f'fetch {self.doi}', sp_cmd='check_output').strip()
         db1 = bibtexparser.loads(bibtexs)
         db2 = bibtexparser.loads(self.bibtex)
         self.assertEqual(db1.entries, db2.entries)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -272,13 +272,18 @@ class TestGitInstall(TestBaseInstall):
         # self.assertTrue(self._exists(".git"))
         # count = sp.check_output(f'cd {self.temp_dir.name} && git rev-list --all --count', shell=True).strip().decode()
         # self.assertEqual(count, '0')
-        count = self.papers('git rev-list --all --count')
+        count = self.papers('git rev-list --all --count', sp_cmd='check_output')
+        count_ = sp.check_output("git rev-list --all --count", shell=True, cwd=self._path('.papers')).decode().strip()
+        self.assertEqual(count, count_)
+        count2 = self.papers('git rev-list --all --count', sp_cmd='check_output')
+        count2_ = sp.check_output("git rev-list --all --count", shell=True, cwd=self._path('.papers')).decode().strip()
+        self.assertEqual(count2, count2_)
         self.papers(f'add {self.anotherbib}')
         # self.papers(f'add --doi 10.5194/bg-8-515-2011')
-        count2 = self.papers('git rev-list --all --count')
-        # The part below fails on github CI, I cannot explain why
+        count2 = self.papers('git rev-list --all --count', sp_cmd='check_output')
+
+        print(count, count2)
         self.assertEqual(int(count2), int(count)+1)
-        # self.papers(f'git log', sp_cmd='check_call')
 
 
     def test_undo(self):


### PR DESCRIPTION
Calling a subprocess papers involves an overhead mostly because all libraries have to be loaded again.
Running the test calling papers.__main__.main(...) offers a significant speedup.