### PR TITLE
add support for 100% manual edit #62

### DIFF
--- a/papers/duplicate.py
+++ b/papers/duplicate.py
@@ -46,7 +46,7 @@ def groupby_equal(entries, eq=None):
         else:
             group = groups[k]
         group.append(e)
-    return sorted(groups.items()) 
+    return sorted(groups.items())
 
 
 def search_duplicates(entries, key=None, eq=None, issorted=False, filter_key=None):


### PR DESCRIPTION
Complements #70 by allowing for a fully manual edit, without providing a DOI or file, thereby fully addressing #62 .
