### PR TITLE
tox, home, conda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ python =
     3.13: py313
 
 [testenv]
+setenv = HOME = {homedir}
 commands = pytest --cov=papers --cov-append --cov-report=term-missing {posargs} -xv
 deps =
     bibtexparser < 2.0.0


### PR DESCRIPTION
I took another look at running tox with the conda envs, and can confirm this seems to have addressed the issue I was having with nonexistent tox coverage for various conda envs

The solution is as follows: for each of the py39, py310, etc envs you'd like to use, ``conda create -n py310 python=3.10, conda activate py310, conda install pytest``.  If necessary, then, re-build your .tox by deleting it an re-running ``tox``, which then finds the relevant python interpreters (since they now exist) and runs all tests in series.

I can confirm I saw 100% test success with all five listed envs.

A small note: adding ``python-xdist" and running pytest with the ``-n auto`` option fails, so there are some race conditions in the tests, but this is another matter. 

This is related to https://github.com/perrette/papers/issues/54 and the solution happens to be the same as https://github.com/perrette/papers/pull/59 .