### PR TITLE
fixes one silly formatting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [Control fields when renaming file](#control-fields-when-renaming-file) for 
 
 It is also possible to do this on a full directory of files, recursively:
 
-   papers add --rename --recursive /home/perette/playground/papers/papers_test
+    papers add --rename --recursive /home/perette/playground/papers/papers_test
 
 where, above, the `papers_test` directory contains a few PDF files.  For each PDF, `papers` will attempt to extract the metadata and add the relevant file to the bibliography and renamed files to the files directory.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ Type `papers status -v` to check your configuration.
 
 Note for developers: executing `papers status -v` while the test suite is running locally
 may destroy your papers installation.  This can be restored by reverting your `papersconfig.json`
-to what it was before the tests start running locally.
+to what it was before the tests start running locally.  This also might destroy your git logs
+for the bibtex and filesdir, in which case you'll have to reinstall.
 
 You also notice a cache directory. All internet requests such as crossref requests are saved in the cache directory.
 This happens regardless of whether `papers` is installed or not.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ command will know about these settings: no need to specify bibtex file or files 
 
 Type `papers status -v` to check your configuration.
 
-Note for developers: executing `papers status -v` while the tests are running may destroy your install.  This can be re-built by reverting your `papersconfig.json` to what it was before the tests start running locally.
+Note for developers: executing `papers status -v` while the test suite is running locally
+may destroy your papers installation.  This can be restored by reverting your `papersconfig.json`
+to what it was before the tests start running locally.
 
 You also notice a cache directory. All internet requests such as crossref requests are saved in the cache directory.
 This happens regardless of whether `papers` is installed or not.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ command will know about these settings: no need to specify bibtex file or files 
 
 Type `papers status -v` to check your configuration.
 
+Note for developers: executing `papers status -v` while the tests are running may destroy your install.  This can be re-built by reverting your `papersconfig.json` to what it was before the tests start running locally.
+
 You also notice a cache directory. All internet requests such as crossref requests are saved in the cache directory.
 This happens regardless of whether `papers` is installed or not.
 


### PR DESCRIPTION
Fixes one mindless formatting typo I introduced into the README -- literally one whitespace.

Sorry about this.