### PR TITLE
enable "extract --recursive"

### DIFF
--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -820,10 +820,10 @@ def extractcmd(parser, o):
         # we have to do this serially.
         # I'd rather leave the futures thing in there, since it does
         # work and is a nice path to a clear speedup TODO.
-    elif len(o.pdf) == 1 and o.pdf.endswith('.pdf'):
+    elif os.path.isfile(o.pdf) == 1 and o.pdf.endswith('.pdf'):
             print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
     else:
-        raise ValueError('extract requires a single pdf or a directory.')
+        raise ValueError('extract requires a single pdf or a directory and --recursive.')
         # TODO trivially extend this for len(o.file) > 1, but no dir
     # print(fetch_bibtex_by_doi(o.doi))
 

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -11,6 +11,7 @@ import shutil
 import itertools
 import fnmatch   # unix-like match
 from slugify import slugify
+import concurrent.futures
 
 import papers
 from papers import logger
@@ -790,7 +791,40 @@ def fetchcmd(parser, o):
         print(fetch_bibtex_by_fulltext_crossref(field))
 
 def extractcmd(parser, o):
-    print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
+    if os.path.isdir(o.pdf) and o.recursive:
+        pdf_files = Path(o.pdf).rglob('*.pdf')
+        futures = []
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            for pdf in pdf_files:
+                future = executor.submit(extract_pdf_metadata,
+                                         pdf,
+                                         search_doi=not o.fulltext,
+                                         search_fulltext=True,
+                                         scholar=o.scholar,
+                                         minwords=o.word_count,
+                                         max_query_words=o.word_count,
+                                         image=o.image)
+                print(future.result())
+                futures.append(future)
+            del pdf_files
+            # for future in futures:
+            #     print(future.result())
+            del futures
+        # OK, a note on the above: clearly, theres parallelization to
+        # be gained here from doing this all concurrently using futures
+        # boyan.penkov saw this run locally on his machine; however
+        # the parallel writes to .cache/papers/crossref.json and
+        # crossref-bibtex.json have race conditions, and clobber
+        # the file format, leaving the base command papers unusable
+        # with json load failures.  I'd be glad to fix it, but for now
+        # we have to do this serially.
+        # I'd rather leave the futures thing in there, since it does
+        # work and is a nice path to a clear speedup TODO.
+    elif len(o.pdf) == 1 and o.pdf.endswith('.pdf'):
+            print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
+    else:
+        raise ValueError('extract requires a single pdf or a directory.')
+        # TODO trivially extend this for len(o.file) > 1, but no dir
     # print(fetch_bibtex_by_doi(o.doi))
 
 
@@ -1265,6 +1299,7 @@ def get_parser(config=None):
     extractp.add_argument('--fulltext', action='store_true', help='fulltext only (otherwise DOI-based)')
     extractp.add_argument('--scholar', action='store_true', help='use google scholar instead of default crossref for fulltext search')
     extractp.add_argument('--image', action='store_true', help='convert to image and use tesseract instead of pdftotext')
+    extractp.add_argument('--recursive', action='store_true', help='takes one directory as an arguement; recursively descends into it and shows extracted bibibinfo for each pdf')
 
     # *** Pure OS related file checks ***
 

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -12,6 +12,7 @@ import itertools
 import fnmatch   # unix-like match
 from slugify import slugify
 import concurrent.futures
+import multiprocessing
 
 import papers
 from papers import logger
@@ -795,31 +796,24 @@ def extractcmd(parser, o):
         pdf_files = Path(o.pdf).rglob('*.pdf')
         futures = []
         with concurrent.futures.ProcessPoolExecutor() as executor:
-            for pdf in pdf_files:
-                future = executor.submit(extract_pdf_metadata,
-                                         pdf,
-                                         search_doi=not o.fulltext,
-                                         search_fulltext=True,
-                                         scholar=o.scholar,
-                                         minwords=o.word_count,
-                                         max_query_words=o.word_count,
-                                         image=o.image)
-                print(future.result())
-                futures.append(future)
-            del pdf_files
-            # for future in futures:
-            #     print(future.result())
-            del futures
-        # OK, a note on the above: clearly, theres parallelization to
-        # be gained here from doing this all concurrently using futures
-        # boyan.penkov saw this run locally on his machine; however
-        # the parallel writes to .cache/papers/crossref.json and
-        # crossref-bibtex.json have race conditions, and clobber
-        # the file format, leaving the base command papers unusable
-        # with json load failures.  I'd be glad to fix it, but for now
-        # we have to do this serially.
-        # I'd rather leave the futures thing in there, since it does
-        # work and is a nice path to a clear speedup TODO.
+            with multiprocessing.Manager() as manager:
+                the_lock = manager.Semaphore(multiprocessing.cpu_count())
+                for pdf in pdf_files:
+                    future = executor.submit(extract_pdf_metadata,
+                                             pdf,
+                                             search_doi=not o.fulltext,
+                                             search_fulltext=True,
+                                             scholar=o.scholar,
+                                             lock=the_lock,
+                                             minwords=o.word_count,
+                                             max_query_words=o.word_count,
+                                             image=o.image)
+                    futures.append(future)
+                del pdf_files
+                for future in futures:
+                    print(future.result())
+                del futures
+                del the_lock
     elif os.path.isfile(o.pdf) == 1 and o.pdf.endswith('.pdf'):
             print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
     else:

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -818,7 +818,7 @@ def extractcmd(parser, o):
         del pdf_files
 
     elif os.path.isfile(o.pdf) == 1 and o.pdf.endswith('.pdf'):
-            print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
+            print(extract_pdf_metadata(o.pdf, None, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
     else:
         raise ValueError('extract requires a single pdf or a directory and --recursive.')
         # TODO trivially extend this for len(o.file) > 1, but no dir

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -797,7 +797,9 @@ def extractcmd(parser, o):
         futures = []
         with concurrent.futures.ProcessPoolExecutor() as executor:
             with multiprocessing.Manager() as manager:
-                local_lock = manager.Semaphore(multiprocessing.cpu_count())
+                # One single lock for the cache access
+                # which has to be done serially
+                local_lock = manager.Lock()
                 for pdf in pdf_files:
                     future = executor.submit(extract_pdf_metadata,
                                              pdf,

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -797,11 +797,11 @@ def extractcmd(parser, o):
         futures = []
         with concurrent.futures.ProcessPoolExecutor() as executor:
             with multiprocessing.Manager() as manager:
-                the_lock = manager.Semaphore(multiprocessing.cpu_count())
+                local_lock = manager.Semaphore(multiprocessing.cpu_count())
                 for pdf in pdf_files:
                     future = executor.submit(extract_pdf_metadata,
                                              pdf,
-                                             lock=the_lock,
+                                             the_lock=local_lock,
                                              search_doi=not o.fulltext,
                                              search_fulltext=True,
                                              scholar=o.scholar,
@@ -811,7 +811,7 @@ def extractcmd(parser, o):
                     futures.append(future)
                 for future in futures:
                     print(future.result())
-                del the_lock
+                del local_lock
         del futures
         del pdf_files
 

--- a/papers/__main__.py
+++ b/papers/__main__.py
@@ -801,19 +801,20 @@ def extractcmd(parser, o):
                 for pdf in pdf_files:
                     future = executor.submit(extract_pdf_metadata,
                                              pdf,
+                                             lock=the_lock,
                                              search_doi=not o.fulltext,
                                              search_fulltext=True,
                                              scholar=o.scholar,
-                                             lock=the_lock,
                                              minwords=o.word_count,
                                              max_query_words=o.word_count,
                                              image=o.image)
                     futures.append(future)
-                del pdf_files
                 for future in futures:
                     print(future.result())
-                del futures
                 del the_lock
+        del futures
+        del pdf_files
+
     elif os.path.isfile(o.pdf) == 1 and o.pdf.endswith('.pdf'):
             print(extract_pdf_metadata(o.pdf, search_doi=not o.fulltext, search_fulltext=True, scholar=o.scholar, minwords=o.word_count, max_query_words=o.word_count, image=o.image))
     else:

--- a/papers/bib.py
+++ b/papers/bib.py
@@ -468,7 +468,7 @@ class Biblio:
         if doi:
             bibtex = fetch_bibtex_by_doi(doi)
         else:
-            bibtex = extract_pdf_metadata(pdf, search_doi, search_fulltext, scholar=scholar)
+            bibtex = extract_pdf_metadata(pdf, None, search_doi, search_fulltext, scholar=scholar)
         bib = parse_string(bibtex)
         entry = bib.entries[0]
 

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -345,7 +345,7 @@ def extract_txt_metadata(
         txt,
         search_doi=True,
         search_fulltext=False,
-        lock,
+        lock=None,
         max_query_words=200,
         scholar=False,
 ):

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -411,9 +411,9 @@ def extract_txt_metadata(
 
     return bibtex
 
-def extract_pdf_metadata(pdf, lock=None, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
+def extract_pdf_metadata(pdf, the_lock, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
     txt = pdfhead(pdf, maxpages, minwords, image=image)
-    return extract_txt_metadata(txt, search_doi, search_fulltext, lock=lock, **kw)
+    return extract_txt_metadata(txt, search_doi, search_fulltext, lock=the_lock, **kw)
 
 @cached('crossref.json')
 def fetch_crossref_by_doi(doi):

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -343,9 +343,9 @@ def query_text(txt, max_query_words=200):
 
 def extract_txt_metadata(
         txt,
-        lock,
         search_doi=True,
         search_fulltext=False,
+        lock,
         max_query_words=200,
         scholar=False,
 ):
@@ -413,7 +413,7 @@ def extract_txt_metadata(
 
 def extract_pdf_metadata(pdf, lock=None, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
     txt = pdfhead(pdf, maxpages, minwords, image=image)
-    return extract_txt_metadata(txt, lock=lock, search_doi, search_fulltext, **kw)
+    return extract_txt_metadata(txt, search_doi, search_fulltext, lock=lock, **kw)
 
 @cached('crossref.json')
 def fetch_crossref_by_doi(doi):

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -343,11 +343,11 @@ def query_text(txt, max_query_words=200):
 
 def extract_txt_metadata(
         txt,
+        lock,
         search_doi=True,
         search_fulltext=False,
         max_query_words=200,
         scholar=False,
-        lock=None,
 ):
     """
     extract metadata from text, by parsing and doi-query, or by fulltext query in google scholar
@@ -411,9 +411,9 @@ def extract_txt_metadata(
 
     return bibtex
 
-def extract_pdf_metadata(pdf, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
+def extract_pdf_metadata(pdf, lock=None, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
     txt = pdfhead(pdf, maxpages, minwords, image=image)
-    return extract_txt_metadata(txt, search_doi, search_fulltext, **kw)
+    return extract_txt_metadata(txt, lock=lock, search_doi, search_fulltext, **kw)
 
 @cached('crossref.json')
 def fetch_crossref_by_doi(doi):

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -364,7 +364,7 @@ def extract_txt_metadata(
             logger.debug('query bibtex by doi')
 
             # lock protect the possible cache write here
-            if lock:
+            if lock is not None:
                 with lock:
                     bibtex = fetch_bibtex_by_doi(doi)
             else:
@@ -391,7 +391,7 @@ def extract_txt_metadata(
         if scholar:
             # TODO this may be a different cache file
             # lock protect the possible cache write here
-            if lock:
+            if lock is not None:
                 with lock:
                     bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
             else:
@@ -399,7 +399,7 @@ def extract_txt_metadata(
         else:
             # lock protect the possible cache write here
             # TODO this may be a different cache file
-            if lock:
+            if lock is not None:
                 with lock:
                     bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
             else:

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -341,7 +341,14 @@ def query_text(txt, max_query_words=200):
     return query_txt
 
 
-def extract_txt_metadata(txt, search_doi=True, search_fulltext=False, max_query_words=200, scholar=False):
+def extract_txt_metadata(
+        txt,
+        search_doi=True,
+        search_fulltext=False,
+        max_query_words=200,
+        scholar=False,
+        lock=None,
+):
     """
     extract metadata from text, by parsing and doi-query, or by fulltext query in google scholar
     """
@@ -355,7 +362,14 @@ def extract_txt_metadata(txt, search_doi=True, search_fulltext=False, max_query_
             doi = parse_doi(txt)
             logger.info('found doi:'+doi)
             logger.debug('query bibtex by doi')
-            bibtex = fetch_bibtex_by_doi(doi)
+
+            # lock protect the possible cache write here
+            if lock:
+                with lock:
+                    bibtex = fetch_bibtex_by_doi(doi)
+            else:
+                bibtex = fetch_bibtex_by_doi(doi)
+
             logger.debug('doi query successful')
 
         except DOIParsingError as error:
@@ -375,16 +389,27 @@ def extract_txt_metadata(txt, search_doi=True, search_fulltext=False, max_query_
         logger.debug('query bibtex by fulltext')
         query_txt = query_text(txt, max_query_words)
         if scholar:
-            bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
+            # TODO this may be a different cache file
+            # lock protect the possible cache write here
+            if lock:
+                with lock:
+                    bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
+            else:
+                bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
         else:
-            bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
+            # lock protect the possible cache write here
+            # TODO this may be a different cache file
+            if lock:
+                with lock:
+                    bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
+            else:
+                bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
         logger.debug('fulltext query successful')
 
     if not bibtex:
         raise ValueError('failed to extract metadata')
 
     return bibtex
-
 
 def extract_pdf_metadata(pdf, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
     txt = pdfhead(pdf, maxpages, minwords, image=image)

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -364,6 +364,7 @@ def extract_txt_metadata(
             logger.debug('query bibtex by doi')
 
             # lock protect the possible cache write here
+            # in the cached decorator
             if lock is not None:
                 with lock:
                     bibtex = fetch_bibtex_by_doi(doi)
@@ -389,23 +390,19 @@ def extract_txt_metadata(
         logger.debug('query bibtex by fulltext')
         query_txt = query_text(txt, max_query_words)
         if scholar:
-            # TODO this may be a different cache file
             # lock protect the possible cache write here
+            # in the decorator
+            # TODO this may be a different cache file
+            # Like, might make sense to pass one lock for arxiv.json
+            # and one for crossref.json
             if lock is not None:
                 with lock:
                     bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
             else:
                 bibtex = fetch_bibtex_by_fulltext_scholar(query_txt)
         else:
-            # lock protect the possible cache write here
-            # TODO this may be a different cache file
-            if lock is not None:
-                with lock:
-                    bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
-            else:
-                bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
+            bibtex = fetch_bibtex_by_fulltext_crossref(query_txt)
         logger.debug('fulltext query successful')
-
     if not bibtex:
         raise ValueError('failed to extract metadata')
 
@@ -596,6 +593,7 @@ def crossref_to_bibtex(message):
 
 
 # @cached('crossref-bibtex-fulltext.json', hashed_key=True)
+# TODO if that gets uncommented above, will have to lock protect that cache
 def fetch_bibtex_by_fulltext_crossref(txt, **kw):
     logger.debug('crossref fulltext seach:\n'+txt)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -2,10 +2,8 @@ import os
 import shutil
 import subprocess as sp
 import tempfile
-import unittest
 from pathlib import Path
 
-import bibtexparser
 from papers.entries import parse_file as bp_parse_file, parse_string, get_entry_val
 from papers.encoding import entry_to_unicode_dict
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,25 +1,150 @@
 import unittest
 import os
+import tempfile
+import shutil
 
 from papers.extract import extract_pdf_metadata
 from papers.entries import parse_string
-from tests.common import paperscmd, prepare_paper
+
+from papers.bib import Biblio
+from tests.common import paperscmd, prepare_paper, prepare_paper2, BibTest
 
 
 class TestSimple(unittest.TestCase):
 
     def setUp(self):
-        self.pdf, self.doi, self.key, self.newkey, self.year, self.bibtex, self.file_rename = prepare_paper()
+        (
+            self.pdf,
+            self.doi,
+            self.key,
+            self.newkey,
+            self.year,
+            self.bibtex,
+            self.file_rename,
+        ) = prepare_paper()
         self.assertTrue(os.path.exists(self.pdf))
 
     def test_doi(self):
-        self.assertEqual(paperscmd(f'doi {self.pdf}', sp_cmd='check_output').strip(), self.doi)
+        self.assertEqual(
+            paperscmd(f"doi {self.pdf}", sp_cmd="check_output").strip(), self.doi
+        )
 
     def test_fetch(self):
-        bibtexs = paperscmd(f'fetch {self.doi}', sp_cmd='check_output').strip()
+        bibtexs = paperscmd(f"fetch {self.doi}", sp_cmd="check_output").strip()
         db1 = parse_string(bibtexs)
         db2 = parse_string(self.bibtex)
-        self.assertEqual([dict(e.items()) for e in db1.entries], [dict(e.items()) for e in db2.entries])
+        self.assertEqual(
+            [dict(e.items()) for e in db1.entries],
+            [dict(e.items()) for e in db2.entries],
+        )
 
     def test_fetch_scholar(self):
         extract_pdf_metadata(self.pdf, scholar=True)
+
+
+class TestAddDir(BibTest):
+    # TODO delete this later
+    def setUp(self):
+        (
+            self.pdf1,
+            self.doi,
+            self.key1,
+            self.newkey1,
+            self.year,
+            self.bibtex1,
+            self.file_rename1,
+        ) = prepare_paper()
+        (
+            self.pdf2,
+            self.si,
+            self.doi,
+            self.key2,
+            self.newkey2,
+            self.year,
+            self.bibtex2,
+            self.file_rename2,
+        ) = prepare_paper2()
+        self.somedir = tempfile.mktemp(prefix="papers.somedir")
+        self.subdir = os.path.join(self.somedir, "subdir")
+        os.makedirs(self.somedir)
+        os.makedirs(self.subdir)
+        shutil.copy(self.pdf1, self.somedir)
+        shutil.copy(self.pdf2, self.subdir)
+        self.mybib = tempfile.mktemp(prefix="papers.bib")
+        paperscmd(f"install --local --no-prompt --bibtex {self.mybib}")
+
+    def test_adddir_pdf(self):
+        self.my = Biblio.load(self.mybib, "")
+        self.my.scan_dir(self.somedir)
+        self.assertEqual(len(self.my.db.entries), 2)
+        keys = [self.my.db.entries[0]["ID"], self.my.db.entries[1]["ID"]]
+        self.assertEqual(
+            sorted(keys), sorted([self.newkey1, self.newkey2])
+        )  # PDF: update key
+
+    def test_adddir_pdf_cmd(self):
+        paperscmd(f"add --recursive --bibtex {self.mybib} {self.somedir}")
+        self.my = Biblio.load(self.mybib, "")
+        self.assertEqual(len(self.my.db.entries), 2)
+        keys = [self.my.db.entries[0]["ID"], self.my.db.entries[1]["ID"]]
+        self.assertEqual(
+            sorted(keys), sorted([self.newkey1, self.newkey2])
+        )  # PDF: update key
+
+    def tearDown(self):
+        os.remove(self.mybib)
+        shutil.rmtree(self.somedir)
+        paperscmd(f"uninstall")
+
+
+class TestRecursiveExtract(unittest.TestCase):
+
+    def setUp(self):
+        (
+            self.pdf1,
+            self.doi1,
+            self.key1,
+            self.newkey1,
+            self.year1,
+            self.bibtex1,
+            self.file_rename1,
+        ) = prepare_paper()
+        (
+            self.pdf2,
+            self.si2,
+            self.doi2,
+            self.key2,
+            self.newkey2,
+            self.year2,
+            self.bibtex2,
+            self.file_rename2,
+        ) = prepare_paper2()
+        self.somedir = tempfile.mktemp(prefix="papers.somedir")
+        self.subdir = os.path.join(self.somedir, "subdir")
+        os.makedirs(self.somedir)
+        os.makedirs(self.subdir)
+        shutil.copy(self.pdf1, self.somedir)
+        shutil.copy(self.pdf2, self.subdir)
+        self.mybib = tempfile.mktemp(prefix="papers.bib")
+        paperscmd(f"install --local --no-prompt --bibtex {self.mybib}")
+        self.assertTrue(os.path.exists(self.pdf1))
+        self.assertTrue(os.path.exists(self.pdf2))
+
+    def test_doi(self):
+        self.assertEqual(
+            paperscmd(f"doi {self.pdf1}", sp_cmd="check_output").strip(), self.doi1
+        )
+
+    def test_fetch(self):
+        bibtexs = paperscmd(f"extract {self.pdf1}", sp_cmd="check_output").strip()
+        db1 = parse_string(bibtexs)
+        db2 = parse_string(self.bibtex1)
+        self.assertEqual(
+            [dict(e.items()) for e in db1.entries],
+            [dict(e.items()) for e in db2.entries],
+        )
+
+    def tearDown(self):
+        os.remove(self.mybib)
+        shutil.rmtree(self.somedir)
+        paperscmd(f"uninstall")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import tempfile
 import shutil
-
+import re
 from papers.extract import extract_pdf_metadata
 from papers.entries import parse_string
 
@@ -130,19 +130,37 @@ class TestRecursiveExtract(unittest.TestCase):
         self.assertTrue(os.path.exists(self.pdf1))
         self.assertTrue(os.path.exists(self.pdf2))
 
-    def test_doi(self):
-        self.assertEqual(
-            paperscmd(f"doi {self.pdf1}", sp_cmd="check_output").strip(), self.doi1
-        )
-
     def test_fetch(self):
-        bibtexs = paperscmd(f"extract {self.pdf1}", sp_cmd="check_output").strip()
-        db1 = parse_string(bibtexs)
-        db2 = parse_string(self.bibtex1)
-        self.assertEqual(
-            [dict(e.items()) for e in db1.entries],
-            [dict(e.items()) for e in db2.entries],
-        )
+        bibtexs = paperscmd(
+            f"extract --recursive {self.somedir}", sp_cmd="check_output"
+        ).strip()
+        the_right_answer = """@article{10.5194/bg-8-515-2011,
+        author = {Perrette, M. and Yool, A. and Quartly, G. D. and Popova, E. E.},
+        doi = {10.5194/bg-8-515-2011},
+        journal = {Biogeosciences},
+        number = {2},
+        pages = {515-524},
+        title = {Near-ubiquity of ice-edge blooms in the Arctic},
+        url = {https://doi.org/10.5194/bg-8-515-2011},
+        volume = {8},
+        year = {2011}
+        }
+        
+        @article{10.5194/esd-4-11-2013,
+        author = {Perrette, M. and Landerer, F. and Riva, R. and Frieler, K. and Meinshausen, M.},
+        doi = {10.5194/esd-4-11-2013},
+        journal = {Earth System Dynamics},
+        number = {1},
+        pages = {11-29},
+        title = {A scaling approach to project regional sea level rise and its uncertainties},
+        url = {https://doi.org/10.5194/esd-4-11-2013},
+        volume = {4},
+        year = {2013}
+        }
+        """
+        processed_bibtexs = re.sub(r"\s+", "", bibtexs)
+        processed_the_right_answer = re.sub(r"\s+", "", the_right_answer)
+        self.assertEqual(processed_bibtexs, processed_the_right_answer)
 
     def tearDown(self):
         os.remove(self.mybib)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -39,7 +39,7 @@ class TestSimple(unittest.TestCase):
         )
 
     def test_fetch_scholar(self):
-        extract_pdf_metadata(self.pdf, scholar=True)
+        extract_pdf_metadata(self.pdf, None, scholar=True)
 
 
 class TestAddDir(BibTest):

--- a/tests/test_filecheck.py
+++ b/tests/test_filecheck.py
@@ -4,16 +4,11 @@ Documented in README: filecheck --rename, --delete-missing (--delete-broken),
 """
 import os
 import shutil
-import subprocess as sp
 import tempfile
-import unittest
-from pathlib import Path
-
-import bibtexparser
 
 from papers.bib import Biblio
 from papers.entries import get_entry_val
-from tests.common import PAPERSCMD, paperscmd, prepare_paper, prepare_paper2, BibTest
+from tests.common import paperscmd, prepare_paper, BibTest
 
 
 class TestFileCheck(BibTest):


### PR DESCRIPTION
`papers extract thing.pdf` is wonderful for checking that the DOI/crossref call on a single PDF is going to make sense.

This PR enables the same behavior on a whole directory recursively, much like `papers add --recursive`.

@perrette I need a pointer on how to write good tests for this one -- I was playing with `test/test_extract.py` but can't figure out how to capture printed output to compare to the database of the two test files you have -- much like in `tests/test_add.py`