### PR TITLE
cache error message

### DIFF
--- a/papers/config.py
+++ b/papers/config.py
@@ -250,7 +250,11 @@ def cached(file, hashed_key=False):
 
     def decorator(fun):
         if os.path.exists(file):
-            cache = json.load(open(file))
+            try:
+                cache = json.load(open(file))
+            except JSONDecodeError as error:
+                logger.warning(f"Unable to read cache, clear it and try again.  Not using cache file. Error was {error}")
+                cache = {}
         else:
             cache = {}
         def decorated(doi):


### PR DESCRIPTION
If you CTRL-C, there's a chance the cache files in `~/.cache/papers` get corrupted -- this should ignore them.  It's up to the user to delete them afterwards and clear it.