### PR TITLE
unhandled assert in query_text

### DIFF
--- a/papers/extract.py
+++ b/papers/extract.py
@@ -337,7 +337,8 @@ def query_text(txt, max_query_words=200):
     # limit overall length
     query_txt = ' '.join(query_txt.strip().split()[:max_query_words])
 
-    assert len(query_txt.split()) >= 3, 'needs at least 3 query words, got: '+repr(query_txt)
+    if not len(query_txt.split()) >= 3:
+        raise ValueError('needs at least 3 query words, got: '+repr(query_txt))
     return query_txt
 
 
@@ -388,7 +389,15 @@ def extract_txt_metadata(txt, search_doi=True, search_fulltext=False, max_query_
 
 def extract_pdf_metadata(pdf, search_doi=True, search_fulltext=True, maxpages=10, minwords=200, image=False, **kw):
     txt = pdfhead(pdf, maxpages, minwords, image=image)
-    return extract_txt_metadata(txt, search_doi, search_fulltext, **kw)
+    try:
+        out = extract_txt_metadata(txt, search_doi, search_fulltext, **kw)
+    except ValueError("Failed to return extracted text metadata, returning default."):
+        doi = 0
+        out = '''@misc{{{doi},
+             doi = {{{doi}}},
+             url = {{http://dx.doi.org/{doi}}},
+            }}'''
+    return out
 
 @cached('crossref.json')
 def fetch_crossref_by_doi(doi):

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -397,7 +397,7 @@ def extract_pdf_metadata(pdf, search_doi=True, search_fulltext=True, maxpages=10
         out = '''@misc{{{doi},
              doi = {{{doi}}},
              url = {{http://dx.doi.org/{doi}}},
-            }}'''
+            }}'''.format(doi=doi)
     return out
 
 @cached('crossref.json')

--- a/papers/extract.py
+++ b/papers/extract.py
@@ -391,7 +391,8 @@ def extract_pdf_metadata(pdf, search_doi=True, search_fulltext=True, maxpages=10
     txt = pdfhead(pdf, maxpages, minwords, image=image)
     try:
         out = extract_txt_metadata(txt, search_doi, search_fulltext, **kw)
-    except ValueError("Failed to return extracted text metadata, returning default."):
+    except ValueError:
+        logger.warn("Failed to return extracted text metadata, returning default.")
         doi = 0
         out = '''@misc{{{doi},
              doi = {{{doi}}},


### PR DESCRIPTION
If `query_text()` fails on the assert (because, say, the pdf ocr fails), we crash; this patch returns this as a `ValueError` or the previously chosen default, which we can then handle.

This is one of the things that -- if we crash at the wrong time -- leaves the caches corrupted; this became evident when trying to run querys concurrently.